### PR TITLE
Using IPv6 adress for AAAA records

### DIFF
--- a/dyndns.sh
+++ b/dyndns.sh
@@ -63,8 +63,14 @@ if [[ "${auth_api_token}" = "" ]]; then
   exit 1
 fi
 
+if [[ "${record_type}" = "AAAA" ]]; then
+  echo "Using IPv6 as AAAA record is to be set."
+  cur_pub_addr=`curl -6 -s https://ifconfig.co`
+else
+  echo "Using IPv4 as record type ${record_type} is not explictly AAAA."
+  cur_pub_addr=`curl -4 -s https://ifconfig.co`
+fi
 
-cur_pub_addr=`curl -s https://ifconfig.me`
 cur_dyn_addr=`curl -s "https://dns.hetzner.com/api/v1/records/${record_id}" -H 'Auth-API-Token: '${auth_api_token} | cut -d ',' -f 4 | cut -d '"' -f 4`
 
 if [[ $cur_pub_addr == $cur_dyn_addr ]]; then

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -67,7 +67,7 @@ if [[ "${record_type}" = "AAAA" ]]; then
   echo "Using IPv6 as AAAA record is to be set."
   cur_pub_addr=`curl -6 -s https://ifconfig.co`
 else
-  echo "Using IPv4 as record type ${record_type} is not explictly AAAA."
+  echo "Using IPv4 as record type ${record_type} is not explicitly AAAA."
   cur_pub_addr=`curl -4 -s https://ifconfig.co`
 fi
 


### PR DESCRIPTION
Hi, maybe this comes handy to anyone else. The script itself works perfectly, for my AAAA records I needed the public IPv6 address and changed the handling accordingly. Does this make sense to you, or did I miss anything?