### PR TITLE
Add awk to explicitly noted depedencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://dns.hetzner.com/api-docs/
 - [`curl`](https://curl.se/)
 - [`dig`](https://gitlab.isc.org/isc-projects/bind9/-/tree/main/bin/dig) (part of [BIND9](https://gitlab.isc.org/isc-projects/bind9)): usually packaged as `dnsutils` or `bind-tools`
 - [`jq`](https://stedolan.github.io/jq/): [install](https://stedolan.github.io/jq/download/)
+- [`awk`](https://en.wikipedia.org/wiki/AWK): For example in the form of [gawk (Gnu Awk)](https://www.gnu.org/software/gawk/manual/gawk.html)
 
 ## Generate Access Token
 First, a new access token must be created in the [Hetzner DNS Console](https://dns.hetzner.com/). This should be copied immediately, because for security reasons it will not be possible to display the token later. But you can generate as many tokens as you like.

--- a/dyndns.sh
+++ b/dyndns.sh
@@ -31,7 +31,7 @@ help:
   -h  - Show Help 
 
 requirements:
-curl, dig and jq are required to run this script.
+curl, dig, jq and awk are required to run this script.
 
 example:
   .exec: ./dyndns.sh -z 98jFjsd8dh1GHasdf7a8hJG7 -r AHD82h347fGAF1 -n dyn
@@ -60,7 +60,7 @@ while getopts ":z:Z:r:n:t:T:h" opt; do
 done
 
 # Check if tools are installed
-for cmd in curl dig jq; do
+for cmd in curl dig jq awk; do
   if ! command -v "${cmd}" &> /dev/null; then
     logger Error "To run the script '${cmd}' is needed, but it seems not to be installed."
     logger Error "Please check 'https://github.com/FarrowStrange/hetzner-api-dyndns#install-tools' for more informations and try again."


### PR DESCRIPTION
awk was not listed as an explicit dependency, but is required. Thus it's added to both the README, Help and the corresponding check.