### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ https://dns.hetzner.com/api-docs/
 ## Install tools
 
 - [`curl`](https://curl.se/)
-- [`dig`](https://gitlab.isc.org/isc-projects/bind9/-/tree/main/bin/dig) (part of [BIND9](https://gitlab.isc.org/isc-projects/bind9)): usually packaged as `dnsutils` or `bind-tools`
 - [`jq`](https://stedolan.github.io/jq/): [install](https://stedolan.github.io/jq/download/)
-- [`awk`](https://en.wikipedia.org/wiki/AWK): For example in the form of [gawk (Gnu Awk)](https://www.gnu.org/software/gawk/manual/gawk.html)
 
 ## Generate Access Token
 First, a new access token must be created in the [Hetzner DNS Console](https://dns.hetzner.com/). This should be copied immediately, because for security reasons it will not be possible to display the token later. But you can generate as many tokens as you like.


### PR DESCRIPTION
I'm resubmitting #33 from a branch with only the two pertinent commits, so as to avoid dragging upstream along with any further changes until they're ready.

I plan to actively maintain my fork, [Hetzname](https://github.com/thcrt/hetzname), going forward, since it's useful and important to me. Of course, I'll push changes upstream, which you are welcome to accept or deny as you wish.

I'd also be happy to maintain this upstream repo if you'd have me :^)

---

- Remove `awk` as a dependency by using `grep` and `tail`.
- Remove `dig` as a dependency by using `curl`[^1].
- Remove `bash` as a dependency by using `sh`[^2].

These changes make use of the tool substantially easier on OpenWRT routers, where storage space is often at a premium and thus unneeded dependencies are sub-optimal.

[^1]: And use [Hetzner's own external IP detector](https://ip.hetzner.com/)
[^2]: On OpenWRT routers, and perhaps other notable systems, this is a symlink to `ash` which works just as well. `bash` is not pre-installed on such devices.